### PR TITLE
fixed map and costmap misalignement due to wrong frame_id

### DIFF
--- a/turtlebot_stdr/launch/turtlebot_in_stdr.launch
+++ b/turtlebot_stdr/launch/turtlebot_in_stdr.launch
@@ -3,6 +3,7 @@
   - stdr
   - move_base
   - amcl
+  - map_server
   - rviz view
  -->
 <launch>
@@ -49,6 +50,12 @@
     <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
     <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
   </node>
+
+  <!-- ****** Maps ***** --> 	
+  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)"> 	
+   <param name="frame_id" value="$(arg global_frame_id)"/> 	
+  </node> 	
+
 
   <!--  ************** Navigation  ***************  -->
   <include file="$(find turtlebot_navigation)/launch/includes/move_base.launch.xml">

--- a/turtlebot_stdr/launch/turtlebot_in_stdr.launch
+++ b/turtlebot_stdr/launch/turtlebot_in_stdr.launch
@@ -55,7 +55,7 @@
   <!--  ****** Maps *****  -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)">
     <param name="frame_id" value="$(arg global_frame_id)"/>
-    <remap from="map" to="new_map"/>
+    <remap from="map" to="rviz_map"/>
   </node>
 
   <!--  ************** Navigation  ***************  -->

--- a/turtlebot_stdr/launch/turtlebot_in_stdr.launch
+++ b/turtlebot_stdr/launch/turtlebot_in_stdr.launch
@@ -12,7 +12,7 @@
   <arg name="stacks"     default="$(optenv TURTLEBOT_STACKS hexagons)"/>  <!-- circles, hexagons -->
   <arg name="3d_sensor"  default="$(optenv TURTLEBOT_3D_SENSOR kinect)"/>  <!-- kinect, asus_xtion_pro -->
   <arg name="laser_topic" default="robot0/laser_0"/> <!-- default laser topic in stdr for 1 robot -->
-  <arg name="odom_topic" default="robot0/odom"/> <!--env default odom topic in stdr for 1 robot --> 
+  <arg name="odom_topic" default="robot0/odom"/>
   <arg name="odom_frame_id" default="map"/> 
   <arg name="base_frame_id" default="robot0"/>  
   <arg name="global_frame_id" default="world"/> 
@@ -52,6 +52,12 @@
     <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
   </node>
 
+  <!--  ****** Maps *****  -->
+  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)">
+    <param name="frame_id" value="$(arg global_frame_id)"/>
+    <remap from="map" to="new_map"/>
+  </node>
+
   <!--  ************** Navigation  ***************  -->
   <include file="$(find turtlebot_navigation)/launch/includes/move_base.launch.xml">
    <arg name="odom_topic" value="$(arg odom_topic)"/>
@@ -84,6 +90,8 @@
   
   <!--  **************** Visualisation ****************  -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find turtlebot_stdr)/rviz/robot_navigation.rviz"/>
+
+
 
   
 </launch>

--- a/turtlebot_stdr/launch/turtlebot_in_stdr.launch
+++ b/turtlebot_stdr/launch/turtlebot_in_stdr.launch
@@ -1,9 +1,7 @@
 <!-- 
   Turtlebot navigation simulation:
   - stdr
-  - map_server
   - move_base
-  - static map
   - amcl
   - rviz view
  -->
@@ -50,12 +48,6 @@
   <node pkg="nodelet" type="nodelet" name="cmd_vel_mux" args="load yocs_cmd_vel_mux/CmdVelMuxNodelet mobile_base_nodelet_manager">
     <param name="yaml_cfg_file" value="$(find turtlebot_bringup)/param/mux.yaml"/>
     <remap from="cmd_vel_mux/output" to="mobile_base/commands/velocity"/>
-  </node>
-
-  <!--  ****** Maps *****  -->
-  <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)">
-    <param name="frame_id" value="$(arg global_frame_id)"/>
-    <remap from="map" to="rviz_map"/>
   </node>
 
   <!--  ************** Navigation  ***************  -->

--- a/turtlebot_stdr/nodes/tf_connector.py
+++ b/turtlebot_stdr/nodes/tf_connector.py
@@ -2,7 +2,6 @@
 __author__ = 'mehdi tlili'
 import rospy
 from tf2_msgs.msg import TFMessage
-from nav_msgs.msg import OccupancyGrid
 import tf
 
 class Remapper(object):

--- a/turtlebot_stdr/nodes/tf_connector.py
+++ b/turtlebot_stdr/nodes/tf_connector.py
@@ -8,7 +8,6 @@ class Remapper(object):
 
     def __init__(self):
         self.br = tf.TransformBroadcaster()
-        self.map_pub = rospy.Publisher("new_map", OccupancyGrid, queue_size=10)
         rospy.Subscriber("/tf", TFMessage, self.tf_remapper)
 
     def tf_remapper(self, msg):

--- a/turtlebot_stdr/nodes/tf_connector.py
+++ b/turtlebot_stdr/nodes/tf_connector.py
@@ -2,25 +2,27 @@
 __author__ = 'mehdi tlili'
 import rospy
 from tf2_msgs.msg import TFMessage
+from nav_msgs.msg import OccupancyGrid
 import tf
 
 class Remapper(object):
 
     def __init__(self):
         self.br = tf.TransformBroadcaster()
+        self.map_pub = rospy.Publisher("new_map", OccupancyGrid, queue_size=10)
+        rospy.Subscriber("/tf", TFMessage, self.tf_remapper)
 
     def tf_remapper(self, msg):
 
-            a = 1
-            if msg.transforms[0].header.frame_id == "/robot0":
-                self.br.sendTransform((0, 0, 0),
-                                      tf.transformations.quaternion_from_euler(0, 0, 0),
-                                      rospy.Time.now(),
-                                      "base_footprint",
-                                      "robot0")
+        if msg.transforms[0].header.frame_id == "/robot0":
+            self.br.sendTransform((0, 0, 0),
+                                  tf.transformations.quaternion_from_euler(0, 0, 0),
+                                  rospy.Time.now(),
+                                  "base_footprint",
+                                  "robot0")
+
 
 if __name__ == '__main__':
     rospy.init_node('remapper_nav')
     remapper = Remapper()
-    rospy.Subscriber("/tf", TFMessage, remapper.tf_remapper)
     rospy.spin()

--- a/turtlebot_stdr/robot/turtlebot.yaml
+++ b/turtlebot_stdr/robot/turtlebot.yaml
@@ -7,8 +7,8 @@ robot:
             []
     - initial_pose:
         x: 2.0
-        y: 2.0
-        theta: 0
+        y: 6.0
+        theta: 0.0
     - laser:
         laser_specifications:
           max_angle: 0.5

--- a/turtlebot_stdr/robot/turtlebot.yaml
+++ b/turtlebot_stdr/robot/turtlebot.yaml
@@ -7,7 +7,7 @@ robot:
             []
     - initial_pose:
         x: 2.0
-        y: 6.0
+        y: 2.0
         theta: 0.0
     - laser:
         laser_specifications:

--- a/turtlebot_stdr/rviz/robot_navigation.rviz
+++ b/turtlebot_stdr/rviz/robot_navigation.rviz
@@ -288,64 +288,7 @@ Visualization Manager:
       Max Intensity: 285
       Min Color: 0; 0; 0
       Min Intensity: 2
-      Name: LaserScan (ir sensors)
-      Position Transformer: XYZ
-      Queue Size: 10
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.05
-      Style: Flat Squares
-      Topic: /ir_scan
-      Use Fixed Frame: true
-      Use rainbow: true
-      Value: true
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 10
-        Min Value: -10
-        Value: true
-      Axis: Z
-      Channel Name: intensity
-      Class: rviz/LaserScan
-      Color: 255; 255; 255
-      Color Transformer: Intensity
-      Decay Time: 0
-      Enabled: true
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 4096
-      Min Color: 0; 0; 0
-      Min Intensity: 0
-      Name: LaserScan (virtual sensor)
-      Position Transformer: XYZ
-      Queue Size: 10
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.02
-      Style: Flat Squares
-      Topic: /virtual_sensor_scan
-      Use Fixed Frame: true
-      Use rainbow: true
-      Value: true
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 10
-        Min Value: -10
-        Value: true
-      Axis: Z
-      Channel Name: intensity
-      Class: rviz/PointCloud2
-      Color: 255; 255; 255
-      Color Transformer: Intensity
-      Decay Time: 0
-      Enabled: true
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 4096
-      Min Color: 0; 0; 0
-      Min Intensity: 0
+
       Name: PointCloud (bumpers)
       Position Transformer: XYZ
       Queue Size: 10
@@ -363,7 +306,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /rviz_map
+      Topic: /map
       Value: true
     - Class: rviz/Group
       Displays:

--- a/turtlebot_stdr/rviz/robot_navigation.rviz
+++ b/turtlebot_stdr/rviz/robot_navigation.rviz
@@ -363,7 +363,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /map
+      Topic: /new_map
       Value: true
     - Class: rviz/Group
       Displays:

--- a/turtlebot_stdr/rviz/robot_navigation.rviz
+++ b/turtlebot_stdr/rviz/robot_navigation.rviz
@@ -363,7 +363,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /new_map
+      Topic: /rviz_map
       Value: true
     - Class: rviz/Group
       Displays:


### PR DESCRIPTION
The map published by STDR had "map" as frame ID whereas I am using "world" as global frame_id. This causes a misalignment between static_map and global_costmap in RVIZ. The only way to fix this was to run a parallel map server that publishes the same static map to a different topic (i.e /new_map) but with a frame_id "world" and choose it in RVIZ instead of "/map".
If my description was not clear, I can show you directly on my computer.
