### PR TITLE
Enable to run Gazebo w/o GUI.

### DIFF
--- a/turtlebot_gazebo/launch/turtlebot_world.launch
+++ b/turtlebot_gazebo/launch/turtlebot_world.launch
@@ -3,12 +3,14 @@
 
   <arg name="base"      value="$(optenv TURTLEBOT_BASE kobuki)"/> <!-- create, roomba -->
   <arg name="battery"   value="$(optenv TURTLEBOT_BATTERY /proc/acpi/battery/BAT0)"/>  <!-- /proc/acpi/battery/BAT0 --> 
+  <arg name="gui" default="true"/>
   <arg name="stacks"    value="$(optenv TURTLEBOT_STACKS hexagons)"/>  <!-- circles, hexagons --> 
   <arg name="3d_sensor" value="$(optenv TURTLEBOT_3D_SENSOR kinect)"/>  <!-- kinect, asus_xtion_pro --> 
 
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="use_sim_time" value="true"/>
     <arg name="debug" value="false"/>
+    <arg name="gui" value="$(arg gui)" />
     <arg name="world_name" value="$(arg world_file)"/>
   </include>
   


### PR DESCRIPTION
When running turlebot_world.launch on serverside (eg. using Gzweb), `empty_world.launch` isn't necessary (or might even shed DISPLAY not found error).
