### PR TITLE
turtlebot_stage: add turtlebot_navigation dependency

### DIFF
--- a/turtlebot_stage/package.xml
+++ b/turtlebot_stage/package.xml
@@ -18,6 +18,7 @@
   <run_depend>stage_ros</run_depend>
   <run_depend>navigation</run_depend>
   <run_depend>turtlebot_bringup</run_depend>
+  <run_depend>turtlebot_navigation</run_depend>
   <run_depend>yocs_virtual_sensor</run_depend>
   <run_depend>yocs_velocity_smoother</run_depend>
 </package>


### PR DESCRIPTION
`"roslaunch stdr_launchers server_with_map_and_gui_plus_robot.launch"` doesn't work out-of-the-box without `turtlebot_navigation`.
